### PR TITLE
fix: add namespace to __OW_NAMESPACE

### DIFF
--- a/src/DevelopmentServer.js
+++ b/src/DevelopmentServer.js
@@ -79,6 +79,8 @@ module.exports = class DevelopmentServer {
     // set openwhisk coordinates for transparent ow client usage.
     process.env.__OW_API_KEY = builder._wskAuth;
     process.env.__OW_API_HOST = builder._wskApiHost;
+    process.env.__OW_NAMESPACE = builder._wskNamespace;
+
     this.params = params;
     return this;
   }


### PR DESCRIPTION
When using aio-lib-state with the Development server, I'm getting an error about a missing namespace, although it is set in my WSK_CONFIG_FILE. With this small change, the error goes away.